### PR TITLE
Holiday timezone fix

### DIFF
--- a/R/difftime_office_hours.R
+++ b/R/difftime_office_hours.R
@@ -15,13 +15,13 @@
 #' @param started Start time of period, as POSIX
 #' @param ended End time of period, as POSIX
 #' @param working_hours Vector of length 2, start and end of office day in hours. Default c(8,16)
-#' @param holidays any holiday or combination of holidays in the '%m/%d/Y' format. Default c('01/01/1901', '01/02/1901')
+#' @param holidays any holiday or combination of holidays in the '%Y-%m-%d' format. Default c('1901-01-01', '1901-01-02')
 
 # Wrapper function to verify input as valid and to handle NA-values.
 difftime_office_hours <- function(started, 
                                   ended, 
                                   working_hours = c(8, 16), 
-                                  holidays = c('01/01/1901', '01/02/1901')) {
+                                  holidays = c('1901-01-01', '1901-01-02')) {
 
     # Assert input is correct.
     ### Assertions of input ####
@@ -71,7 +71,7 @@ difftime_office_hours <- function(started,
 #' @param started Start time of period, as POSIX. NA-values is NOT allowed
 #' @param ended End time of period, as POSIX. NA-values is NOT allowed
 #' @param working_hours Vector of length 2, start and end of office day in hours. Default c(8,16)
-#' @param holidays any holiday or combination of holidays in the '%m/%d/Y' format. Default c('01/01/1901', '01/02/1901')
+#' @param holidays any holiday or combination of holidays in the '%Y-%m-%d' format. Default c('1901-01-01', '1901-01-02')
 #' @return Number of office hours between time stamps
 #' @keywords internal
 
@@ -96,7 +96,7 @@ difftime_office_hours_no_NA <- function(started, ended, working_hours, holidays)
       }
     
     # Hours from start time stamp to end of working hours if not a holiday or a non-work day.
-    hours_first_day <- day_end - ifelse(format(started, '%m/%d/%Y') %in% holidays,
+    hours_first_day <- day_end - ifelse(format(started, '%Y-%m-%d') %in% holidays,
                                         day_end,
                                         ifelse(work_days_n(started) == 1,
                                                timestamp_day(started),
@@ -104,7 +104,7 @@ difftime_office_hours_no_NA <- function(started, ended, working_hours, holidays)
                                         )
     
     # Hours from start of working hours to time stamp if not a holiday or a non-work day.
-    hours_last_day <- (ifelse(format(ended, '%m/%d/%Y') %in% holidays,
+    hours_last_day <- (ifelse(format(ended, '%Y-%m-%d') %in% holidays,
                              day_start,
                              ifelse(work_days_n(ended) == 1, 
                                     timestamp_day(ended), 
@@ -112,7 +112,7 @@ difftime_office_hours_no_NA <- function(started, ended, working_hours, holidays)
   
     #If calculating same-day times:
     hours_first_and_last_day <- ifelse(lubridate::date(started) == lubridate::date(ended) &
-                                           !format(started, '%m/%d/%Y') %in% holidays,
+                                           !format(started, '%Y-%m-%d') %in% holidays,
                                        min(timestamp_day(ended), day_end) - 
                                            max(timestamp_day(started), day_start),
                                        hours_first_day + hours_last_day) %>% 
@@ -189,11 +189,11 @@ dates_span_fun <- function(started, ended)	{
 #' Filter sequence of days in span to exclude holidays. Vectorized.
 #'
 #' @param dates a numeric vector of number of working days in period
-#' @param holidays any holiday or combination of holidays in the '%m/%d/Y' format. Default c('01/01/1901', '01/02/1901')
+#' @param holidays any holiday or combination of holidays in the '%Y-%m-%d' format. Default c('1901-01-01', '1901-01-02')
 #' @return a numeric vector of number of working days (minus holidays) in period
 #' @keywords internal
 grab_non_holidays_only <- function(dates, holidays) {
-  holidays_to_remove <- holidays %>% lubridate::mdy(tz = 'UTC') %>% as.POSIXct(tz = 'UTC')
+  holidays_to_remove <- holidays %>% as.POSIXct()
   non_holidays <- dates [! dates %in% holidays_to_remove]
   return(non_holidays)
 }

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ Additional holliday days can probably be added by modifying the internal functio
 Arguments:  
 * `started` Start time of period, as POSIX
 * `ended` End time of period, as POSIX
-* `working_hours` Vector of lenght 2, start and end of office day in hours. Default c(8,16)  
-  
+* `working_hours` Vector of length 2, start and end of office day in hours. Default c(8,16)  
+* `holidays` Vector of dates in (%m/%d/%Y) format  to calculate as holidays. Default c('01/01/1901', '01/02/1901')
+
 Output is of class Duration from package `lubridate`, units is seconds. 
 
 ## Installation
-`devtools::install_github("janzzon/difftimeOffice")`
+`remotes::install_github("johncassil/difftimeOffice")`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A package containing one exported function `difftime_office_hours()`, which calc
   
 Office hours is default monday to friday, 8:00 to 16:00.
 Start and end time of day can be set with argument `working_hours`.
-Additional holliday days can probably be added by modifying the internal function `difftimeOffice:::work_days_atomic()`.  
+Holidays can be provided to the function with argument `holidays`. (This ensures that any holidays are compatible, no matter the country or office)
 
 ## Usage
 `difftime_office_hours(started, ended, working_hours = c(8, 16))`  

--- a/tests/testthat/test-difftime_office_hours.R
+++ b/tests/testthat/test-difftime_office_hours.R
@@ -157,3 +157,36 @@ test_that("Modified working_hours, different day",{
     ,rep(lubridate::duration(-60, units = "hours"),4)
   )
 })
+
+
+test_that("Holidays are removed as expected",{
+  expect_equal(
+    difftime_office_hours( #first day is a holiday
+      as.POSIXct("2016-01-05 8:00:00"), as.POSIXct("2016-01-07 16:00:00"),working_hours = c(8, 16),
+      holidays = "2016-01-05"
+    ),lubridate::duration(16, units = "hours")
+  )
+  
+  expect_equal(
+    difftime_office_hours( #first two days are holidays
+      as.POSIXct("2016-01-05 8:00:00"), as.POSIXct("2016-01-07 16:00:00"),working_hours = c(8, 16),
+      holidays = c("2016-01-05","2016-01-06")
+    ),lubridate::duration(8, units = "hours")
+  )
+  
+  expect_equal(
+    difftime_office_hours( #both days are holidays
+      as.POSIXct("2016-01-05 8:00:00"), as.POSIXct("2016-01-06 16:00:00"),working_hours = c(8, 16),
+      holidays = c("2016-01-05","2016-01-06")
+    ),lubridate::duration(0, units = "hours")
+  )
+  
+  expect_equal(
+    difftime_office_hours( #middle day is a holiday
+      as.POSIXct("2016-01-05 8:00:00"), as.POSIXct("2016-01-07 16:00:00"),working_hours = c(8, 16),
+      holidays = c("2016-01-06")
+    ),lubridate::duration(16, units = "hours")
+  )
+  
+  
+})


### PR DESCRIPTION
Let me know what you think of this approach - it keeps the holidays inputs as character, but makes them look more similar in format to the POSIX inputs in the tests, and converts to POSIX without specifying a timezone (so they will be in the user's timezone). 

So this now returns 8 hours as expected:

```
 difftime_office_hours( #first two days are holidays
      as.POSIXct("2016-01-05 8:00:00"), as.POSIXct("2016-01-07 16:00:00"),working_hours = c(8, 16),
      holidays = c("2016-01-05","2016-01-06")
    )

[1] "28800s (~8 hours)"

```

Also added some tests to address this type of case.